### PR TITLE
chore: update CI workflow branch for GitHub Actions

### DIFF
--- a/.github/workflows/ci-fast.yaml
+++ b/.github/workflows/ci-fast.yaml
@@ -3,14 +3,13 @@ name: CI Fast
 on:
   workflow_dispatch:
   push:
-    branches: ["macos-build-test"]
+    branches: ["github-actions-test"]
     tags:
       - "v*"
 
 jobs:
   build-macos:
     runs-on: macos-latest
-    if: startsWith(github.ref, 'refs/tags/v')
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
- Changed the branch for push events from "macos-build-test" to "github-actions-test".
- Removed conditional check for tag references in the build job.