### PR TITLE
docs: add Arch Linux AUR installation and uninstallation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,6 +412,22 @@ cd reinplayer_linux_amd64_portable
 
 ---
 
+### 🏅 Method 4: Arch Linux / Manjaro (AUR)
+
+**Install seamlessly from the [Arch User Repository](https://aur.archlinux.org/packages/reinplayer-bin) using an AUR helper (e.g., `yay` or `paru`):**
+
+```bash
+yay -S reinplayer-bin
+```
+
+**Benefits:**
+
+- ✅ Dependencies (`mpv`, `gtk3`) are handled automatically
+- ✅ Desktop shortcut (`.desktop`) and icon are pre-configured
+- ✅ Easy uninstallation and system integration
+
+---
+
 ### 🗑️ Uninstall
 
 **Snap:**
@@ -424,6 +440,12 @@ sudo snap remove reinplayer
 
 ```bash
 sudo apt remove reinplayer
+```
+
+**Arch Linux / Manjaro (AUR):**
+
+```bash
+yay -R reinplayer-bin
 ```
 
 ---


### PR DESCRIPTION
Hi Ahurein,
Following up on Issue #49, I have packaged ReinPlayer for Arch Linux and published it to the AUR as reinplayer-bin.
This PR adds the AUR installation method to the README.md to help Arch / Manjaro users install it seamlessly without manually dealing with dependencies or desktop entries. I also added the corresponding AUR uninstall command to the Uninstall section.
I kept the formatting completely consistent with your previous methods. Thanks for the great software!